### PR TITLE
fix: move Swagger UI to root path

### DIFF
--- a/apps/api/main.ts
+++ b/apps/api/main.ts
@@ -78,7 +78,7 @@ app.get(
   }),
 );
 
-app.get('/ui', swaggerUI({ url: '/openapi' }));
+app.get('/', swaggerUI({ url: '/openapi' }));
 
 Deno.serve({
   port: env.PORT,

--- a/packages/env/mod.ts
+++ b/packages/env/mod.ts
@@ -2,7 +2,7 @@ import z from 'zod';
 
 const envSchema = z.object({
   PORT: z.coerce.number().int().default(3000),
-  HOST: z.string().default('0.0.0.0'),
+  HOST: z.string().default('localhost'),
 
   SIMULON_PUBLIC_URL: z.string().optional(),
 });


### PR DESCRIPTION
This pull request includes changes to the `apps/api/main.ts` and `packages/env/mod.ts` files to update the API endpoint and modify environment variable defaults.

API endpoint update:

* [`apps/api/main.ts`](diffhunk://#diff-e63dc7f55c6ab7e72ed2cc2bcfd2072a6079b2b4c3383603b8ed16930fa9d22dL81-R81): Changed the Swagger UI endpoint from `/ui` to `/` to simplify the root URL for accessing the API documentation.

Environment variable defaults modification:

* [`packages/env/mod.ts`](diffhunk://#diff-e5629cbd3e3a2f7ecc47d3cb814a58d4701c3398f9a66397cc5742b88f92a618L5-R5): Updated the default value of the `HOST` environment variable from `0.0.0.0` to `localhost` to improve local development experience.