### PR TITLE
fix: add missed OpenAPI examples

### DIFF
--- a/apps/api/airline/index.ts
+++ b/apps/api/airline/index.ts
@@ -190,7 +190,9 @@ airline.post(
         content: {
           'application/json': {
             schema: resolver(z.object({
-              value: z.string(),
+              value: z.string().openapi({
+                example: faker.airline.seat(),
+              }),
             })),
           },
         },

--- a/apps/api/database/index.ts
+++ b/apps/api/database/index.ts
@@ -18,7 +18,9 @@ database.post(
           'application/json': {
             schema: resolver(
               z.object({
-                value: z.string(),
+                value: z.string().openapi({
+                  example: faker.database.column(),
+                }),
               }),
             ),
           },
@@ -41,7 +43,9 @@ database.post(
           'application/json': {
             schema: resolver(
               z.object({
-                value: z.string(),
+                value: z.string().openapi({
+                  example: faker.database.type(),
+                }),
               }),
             ),
           },
@@ -64,7 +68,9 @@ database.post(
           'application/json': {
             schema: resolver(
               z.object({
-                value: z.string(),
+                value: z.string().openapi({
+                  example: faker.database.collation(),
+                }),
               }),
             ),
           },
@@ -87,7 +93,9 @@ database.post(
           'application/json': {
             schema: resolver(
               z.object({
-                value: z.string(),
+                value: z.string().openapi({
+                  example: faker.database.engine(),
+                }),
               }),
             ),
           },
@@ -110,7 +118,9 @@ database.post(
           'application/json': {
             schema: resolver(
               z.object({
-                value: z.string(),
+                value: z.string().openapi({
+                  example: faker.database.mongodbObjectId(),
+                }),
               }),
             ),
           },

--- a/apps/api/word/index.ts
+++ b/apps/api/word/index.ts
@@ -17,7 +17,9 @@ word.post(
         content: {
           'application/json': {
             schema: resolver(z.object({
-              value: z.string(),
+              value: z.string().openapi({
+                example: faker.word.adjective(),
+              }),
             })),
           },
         },
@@ -61,7 +63,9 @@ word.post(
         content: {
           'application/json': {
             schema: resolver(z.object({
-              value: z.string(),
+              value: z.string().openapi({
+                example: faker.word.adverb(),
+              }),
             })),
           },
         },
@@ -105,7 +109,9 @@ word.post(
         content: {
           'application/json': {
             schema: resolver(z.object({
-              value: z.string(),
+              value: z.string().openapi({
+                example: faker.word.conjunction(),
+              }),
             })),
           },
         },
@@ -149,7 +155,9 @@ word.post(
         content: {
           'application/json': {
             schema: resolver(z.object({
-              value: z.string(),
+              value: z.string().openapi({
+                example: faker.word.interjection(),
+              }),
             })),
           },
         },
@@ -193,7 +201,9 @@ word.post(
         content: {
           'application/json': {
             schema: resolver(z.object({
-              value: z.string(),
+              value: z.string().openapi({
+                example: faker.word.noun(),
+              }),
             })),
           },
         },
@@ -237,7 +247,9 @@ word.post(
         content: {
           'application/json': {
             schema: resolver(z.object({
-              value: z.string(),
+              value: z.string().openapi({
+                example: faker.word.preposition(),
+              }),
             })),
           },
         },
@@ -281,7 +293,9 @@ word.post(
         content: {
           'application/json': {
             schema: resolver(z.object({
-              value: z.string(),
+              value: z.string().openapi({
+                example: faker.word.sample(),
+              }),
             })),
           },
         },
@@ -325,7 +339,9 @@ word.post(
         content: {
           'application/json': {
             schema: resolver(z.object({
-              value: z.string(),
+              value: z.string().openapi({
+                example: faker.word.verb(),
+              }),
             })),
           },
         },
@@ -368,7 +384,11 @@ word.post(
         description: 'Success',
         content: {
           'application/json': {
-            schema: resolver(z.array(z.string())),
+            schema: resolver(z.object({
+              value: z.string().openapi({
+                example: faker.word.words(),
+              }),
+            })),
           },
         },
       },

--- a/packages/env/mod.ts
+++ b/packages/env/mod.ts
@@ -2,7 +2,7 @@ import z from 'zod';
 
 const envSchema = z.object({
   PORT: z.coerce.number().int().default(3000),
-  HOST: z.string().default('localhost'),
+  HOST: z.string().default('127.0.0.1'),
 
   SIMULON_PUBLIC_URL: z.string().optional(),
 });


### PR DESCRIPTION
This pull request includes changes to various API endpoints to add example values to the OpenAPI schema definitions using the `faker` library. Additionally, a default value for the `HOST` environment variable has been updated.

Improvements to API schema definitions:

* [`apps/api/airline/index.ts`](diffhunk://#diff-4baac36a2f6a32c4a35aaca22ca18302b7a951f8eea7c7b8efe45181ca5784d2L193-R195): Added example value for `value` field using `faker.airline.seat()`.
* [`apps/api/database/index.ts`](diffhunk://#diff-7c3c08fb5f5e2565916ac93b7ae2a156eb30d1ee43cbd33006de1c314a233da3L21-R23): Added example values for `value` field using various `faker.database` methods, including `column()`, `type()`, `collation()`, `engine()`, and `mongodbObjectId()`. [[1]](diffhunk://#diff-7c3c08fb5f5e2565916ac93b7ae2a156eb30d1ee43cbd33006de1c314a233da3L21-R23) [[2]](diffhunk://#diff-7c3c08fb5f5e2565916ac93b7ae2a156eb30d1ee43cbd33006de1c314a233da3L44-R48) [[3]](diffhunk://#diff-7c3c08fb5f5e2565916ac93b7ae2a156eb30d1ee43cbd33006de1c314a233da3L67-R73) [[4]](diffhunk://#diff-7c3c08fb5f5e2565916ac93b7ae2a156eb30d1ee43cbd33006de1c314a233da3L90-R98) [[5]](diffhunk://#diff-7c3c08fb5f5e2565916ac93b7ae2a156eb30d1ee43cbd33006de1c314a233da3L113-R123)
* [`apps/api/word/index.ts`](diffhunk://#diff-f857aa1b3683b2b46f1999160c9742baccce21db1ad1382e3a4e504da6bbcca2L20-R22): Added example values for `value` field using various `faker.word` methods, including `adjective()`, `adverb()`, `conjunction()`, `interjection()`, `noun()`, `preposition()`, `sample()`, `verb()`, and `words()`. [[1]](diffhunk://#diff-f857aa1b3683b2b46f1999160c9742baccce21db1ad1382e3a4e504da6bbcca2L20-R22) [[2]](diffhunk://#diff-f857aa1b3683b2b46f1999160c9742baccce21db1ad1382e3a4e504da6bbcca2L64-R68) [[3]](diffhunk://#diff-f857aa1b3683b2b46f1999160c9742baccce21db1ad1382e3a4e504da6bbcca2L108-R114) [[4]](diffhunk://#diff-f857aa1b3683b2b46f1999160c9742baccce21db1ad1382e3a4e504da6bbcca2L152-R160) [[5]](diffhunk://#diff-f857aa1b3683b2b46f1999160c9742baccce21db1ad1382e3a4e504da6bbcca2L196-R206) [[6]](diffhunk://#diff-f857aa1b3683b2b46f1999160c9742baccce21db1ad1382e3a4e504da6bbcca2L240-R252) [[7]](diffhunk://#diff-f857aa1b3683b2b46f1999160c9742baccce21db1ad1382e3a4e504da6bbcca2L284-R298) [[8]](diffhunk://#diff-f857aa1b3683b2b46f1999160c9742baccce21db1ad1382e3a4e504da6bbcca2L328-R344) [[9]](diffhunk://#diff-f857aa1b3683b2b46f1999160c9742baccce21db1ad1382e3a4e504da6bbcca2L371-R391)

Environment configuration update:

* [`packages/env/mod.ts`](diffhunk://#diff-e5629cbd3e3a2f7ecc47d3cb814a58d4701c3398f9a66397cc5742b88f92a618L5-R5): Changed the default value for the `HOST` environment variable from `localhost` to `127.0.0.1`.