### PR TITLE
feat: replace Swagger UI with Scalar

### DIFF
--- a/apps/api/main.ts
+++ b/apps/api/main.ts
@@ -27,8 +27,8 @@ import { vehicle } from './vehicle/index.ts';
 import { word } from './word/index.ts';
 import { json } from './json/index.ts';
 import { openAPISpecs } from 'hono-openapi';
-import { swaggerUI } from '@hono/swagger-ui';
 import { env } from '@simulon/env';
+import { apiReference } from '@scalar/hono-api-reference';
 
 const faker = new Hono();
 
@@ -78,7 +78,14 @@ app.get(
   }),
 );
 
-app.get('/', swaggerUI({ url: '/openapi' }));
+app.get(
+  '/',
+  apiReference({
+    spec: {
+      url: '/openapi',
+    },
+  }),
+);
 
 Deno.serve({
   port: env.PORT,

--- a/deno.json
+++ b/deno.json
@@ -14,8 +14,8 @@
   "imports": {
     "@apidevtools/json-schema-ref-parser": "npm:@apidevtools/json-schema-ref-parser@^11.7.3",
     "@faker-js/faker": "npm:@faker-js/faker@^9.3.0",
-    "@hono/swagger-ui": "npm:@hono/swagger-ui@^0.5.0",
     "@hono/zod-validator": "npm:@hono/zod-validator@^0.4.2",
+    "@scalar/hono-api-reference": "npm:@scalar/hono-api-reference@^0.5.165",
     "@types/json-schema": "npm:@types/json-schema@^7.0.15",
     "hono": "npm:hono@^4.6.14",
     "hono-openapi": "npm:hono-openapi@^0.2.1",

--- a/deno.lock
+++ b/deno.lock
@@ -3,8 +3,8 @@
   "specifiers": {
     "npm:@apidevtools/json-schema-ref-parser@^11.7.3": "11.7.3",
     "npm:@faker-js/faker@^9.3.0": "9.3.0",
-    "npm:@hono/swagger-ui@0.5": "0.5.0_hono@4.6.14",
     "npm:@hono/zod-validator@~0.4.2": "0.4.2_hono@4.6.14_zod@3.24.1",
+    "npm:@scalar/hono-api-reference@~0.5.165": "0.5.165_hono@4.6.14",
     "npm:@types/json-schema@7.0.15": "7.0.15",
     "npm:@types/json-schema@^7.0.15": "7.0.15",
     "npm:hono-openapi@0.2.1": "0.2.1_arktype@2.0.0-rc.25_hono@4.6.14_@sinclair+typebox@0.34.11_valibot@1.0.0-beta.9_zod@3.24.1",
@@ -42,12 +42,6 @@
         "hono"
       ]
     },
-    "@hono/swagger-ui@0.5.0_hono@4.6.14": {
-      "integrity": "sha512-MWYYSv9kC8IwFBLZdwgZZMT9zUq2C/4/ekuyEYOkHEgUMqu+FG3eebtBZ4ofMh60xYRxRR2BgQGoNIILys/PFg==",
-      "dependencies": [
-        "hono"
-      ]
-    },
     "@hono/typebox-validator@0.2.6_@sinclair+typebox@0.34.11_hono@4.6.14": {
       "integrity": "sha512-x+Q7RWiw6rJmJs7MDgtvRbS7ViXXEzqimC0duY4or7y1f89f5Z3KCQSdUSVka+Uv0HZ/O0ZNt+ixNDxfJLi4hA==",
       "dependencies": [
@@ -72,11 +66,35 @@
     "@jsdevtools/ono@7.1.3": {
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
+    "@scalar/hono-api-reference@0.5.165_hono@4.6.14": {
+      "integrity": "sha512-UOdH9vKQxNC5wi3fQufq44g93x3oE7YoeI1bdLncbrK3Nm+XtLe4Wc0kSpz1n6gsjvqSJij/ioXmkC8OJpM5hA==",
+      "dependencies": [
+        "@scalar/types",
+        "hono"
+      ]
+    },
+    "@scalar/openapi-types@0.1.5": {
+      "integrity": "sha512-6geH9ehvQ/sG/xUyy3e0lyOw3BaY5s6nn22wHjEJhcobdmWyFER0O6m7AU0ZN4QTjle/gYvFJOjj552l/rsNSw=="
+    },
+    "@scalar/types@0.0.25": {
+      "integrity": "sha512-sGnOFnfiSn4o23rklU/jrg81hO+630bsFIdHg8MZ/w2Nc6IoUwARA2hbe4d4Fg+D0KBu40Tan/L+WAYDXkTJQg==",
+      "dependencies": [
+        "@scalar/openapi-types",
+        "@unhead/schema"
+      ]
+    },
     "@sinclair/typebox@0.34.11": {
       "integrity": "sha512-zE9pWGVSG82z+sFO+oUmqmqRVm8Wg5sVhmljYi1fDhLOSphBBy939QmC/qXcKFWqTiRJ6keyG4y75bIoTPRBAw=="
     },
     "@types/json-schema@7.0.15": {
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
+    },
+    "@unhead/schema@1.11.14": {
+      "integrity": "sha512-V9W9u5tF1/+TiLqxu+Qvh1ShoMDkPEwHoEo4DKdDG6ko7YlbzFfDxV6el9JwCren45U/4Vy/4Xi7j8OH02wsiA==",
+      "dependencies": [
+        "hookable",
+        "zhead"
+      ]
     },
     "@valibot/to-json-schema@1.0.0-beta.3_valibot@1.0.0-beta.9": {
       "integrity": "sha512-20XQh1u5sOLwS3NOB7oHCo3clQ9h4GlavXgLKMux2PYpHowb7P97cND0dg8T3+fE1WoKVACcLppvzAPpSx0F+Q==",
@@ -118,6 +136,9 @@
     "hono@4.6.14": {
       "integrity": "sha512-j4VkyUp2xazGJ8eCCLN1Vm/bxdvm/j5ZuU9AIjLu9vapn2M44p9L3Ktr9Vnb2RN2QtcR/wVjZVMlT5k7GJQgPw=="
     },
+    "hookable@5.5.3": {
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="
+    },
     "js-yaml@4.1.0": {
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dependencies": [
@@ -140,6 +161,9 @@
     "valibot@1.0.0-beta.9": {
       "integrity": "sha512-yEX8gMAZ2R1yI2uwOO4NCtVnJQx36zn3vD0omzzj9FhcoblvPukENIiRZXKZwCnqSeV80bMm8wNiGhQ0S8fiww=="
     },
+    "zhead@2.2.4": {
+      "integrity": "sha512-8F0OI5dpWIA5IGG5NHUg9staDwz/ZPxZtvGVf01j7vHqSyZ0raHY+78atOVxRqb73AotX22uV1pXt3gYSstGag=="
+    },
     "zod-openapi@4.2.0_zod@3.24.1": {
       "integrity": "sha512-lnm1e2X5/Ymox5mYxdspy/y52Hb4rPxG1bcwOuHS+YIpxQNEt9s8G4zo34jm0M3+q71TAxgqzcbPLiBXrsfsGA==",
       "dependencies": [
@@ -154,8 +178,8 @@
     "dependencies": [
       "npm:@apidevtools/json-schema-ref-parser@^11.7.3",
       "npm:@faker-js/faker@^9.3.0",
-      "npm:@hono/swagger-ui@0.5",
       "npm:@hono/zod-validator@~0.4.2",
+      "npm:@scalar/hono-api-reference@~0.5.165",
       "npm:@types/json-schema@^7.0.15",
       "npm:hono-openapi@~0.2.1",
       "npm:hono@^4.6.14",


### PR DESCRIPTION
This pull request includes changes to update the API reference handling in the `apps/api/main.ts` file and the associated dependencies in `deno.json`. The most important changes include replacing the `swagger-ui` package with the `hono-api-reference` package.

Updates to API reference handling:

* [`apps/api/main.ts`](diffhunk://#diff-e63dc7f55c6ab7e72ed2cc2bcfd2072a6079b2b4c3383603b8ed16930fa9d22dL30-R31): Replaced the import of `swaggerUI` from `@hono/swagger-ui` with `apiReference` from `@scalar/hono-api-reference`.

Dependency updates:

* [`deno.json`](diffhunk://#diff-54337bcff4b919f6b8b4e0b0e51d06fd9124562fde88899be726c24b7e354b7cL17-R18): Removed the `@hono/swagger-ui` package and added the `@scalar/hono-api-reference` package.