### PR TITLE
fix: add API version to OpenAPI spec

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,3 +43,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            SIMULON_VERSION=${{ github.event.release.tag_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
 FROM denoland/deno:2.1.1
 
+ARG SIMULON_VERSION
+
 WORKDIR /app
 
 ADD . /app
 
 RUN deno install --entrypoint apps/api/main.ts
+
+ENV SIMULON_VERSION=${SIMULON_VERSION}
 
 CMD ["run", "--allow-net", "--allow-env", "--allow-read", "apps/api/main.ts"]

--- a/apps/api/main.ts
+++ b/apps/api/main.ts
@@ -72,7 +72,7 @@ app.get(
     documentation: {
       info: {
         title: 'Simulon API',
-        version: '1.0.0',
+        version: env.SIMULON_VERSION,
       },
       servers: [
         { url: env.SIMULON_PUBLIC_URL ?? `http://${env.HOST}:${env.PORT}` },

--- a/packages/env/mod.ts
+++ b/packages/env/mod.ts
@@ -5,6 +5,10 @@ const envSchema = z.object({
   PORT: z.coerce.number().int().default(3000),
   HOST: z.string().default('127.0.0.1'),
 
+  SIMULON_VERSION: z.string().transform((v) => v.replace(/^v/, '')).default(
+    '0.0.0',
+  ),
+
   SIMULON_PUBLIC_URL: z.string().optional(),
 });
 


### PR DESCRIPTION
This pull request introduces several changes to integrate the `SIMULON_VERSION` environment variable into the Docker build and application runtime. The most important changes include updating the Dockerfile to accept a build argument for the version, modifying the API to use this version, and ensuring the environment schema includes the version.

Integration of `SIMULON_VERSION`:

* [`.github/workflows/docker-publish.yml`](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R46-R47): Added `build-args` to pass the release tag name as `SIMULON_VERSION` during the Docker build process.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R3-R12): Introduced an `ARG` for `SIMULON_VERSION` and set it as an environment variable within the Docker container.
* [`apps/api/main.ts`](diffhunk://#diff-e63dc7f55c6ab7e72ed2cc2bcfd2072a6079b2b4c3383603b8ed16930fa9d22dL75-R75): Updated the API documentation version to use the `SIMULON_VERSION` environment variable.
* [`packages/env/mod.ts`](diffhunk://#diff-e5629cbd3e3a2f7ecc47d3cb814a58d4701c3398f9a66397cc5742b88f92a618R8-R11): Added `SIMULON_VERSION` to the environment schema with a default value and transformation to strip a leading 'v'.